### PR TITLE
Feat : 기자재 디테일 페이지 이미지 리스트 컴포넌트 구현

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,5 @@
 import { ThemeProvider } from "styled-components";
+import DetailImage from "./components/DetailImage";
 import { GlobalStyle } from "./styles/globalStyle";
 import { theme } from "./styles/theme";
 
@@ -7,7 +8,8 @@ function App() {
     <>
       <ThemeProvider theme={theme}>
         <GlobalStyle />
-        <h1>test2</h1>
+        {/* <h1>test2</h1> */}
+        <DetailImage />
       </ThemeProvider>
     </>
   );

--- a/src/components/DetailImage/index.jsx
+++ b/src/components/DetailImage/index.jsx
@@ -1,0 +1,41 @@
+import { useState } from "react"
+import Image from "../../modules/Image"
+import * as S from "./style"
+
+// dummy images -> 
+const images = [
+  'https://img.freepik.com/free-photo/green-tea-bud-leaves-green-tea-plantations-morning_335224-955.jpg?w=996&t=st=1677078194~exp=1677078794~hmac=d825794a2549585c3b9374dc71976a8e85529189b00393eaa9f8fe4f76c36825',
+  'https://img.freepik.com/free-photo/peak-bamboo-lijiang-rural-mist_1417-410.jpg?w=996&t=st=1677078207~exp=1677078807~hmac=7e23a062e9420fadf600079d1364d67e11ff7c59f0c0b70bd40695105217f3aa',
+  'https://img.freepik.com/premium-photo/viewpoint-view-sunset-attractions-thailand_38404-284.jpg?w=996',
+  'https://img.freepik.com/free-photo/green-field_1417-1577.jpg?w=996&t=st=1677078235~exp=1677078835~hmac=9076c68eeb626a5e8ef70dea974753297a00d42399d8c5831684b3db147f0509',
+]
+
+export default function DetailImage() {
+  const [currentImg, setCurrentImg] = useState(images[0])
+  
+  const handleImgChange = (e) => {
+    setCurrentImg(e.target.src)
+  }
+
+  return (
+    <S.ImageWrap>
+      <ul>
+        {
+          images.map((image, index) => {
+            return (
+              <S.ImageLi key={index} >
+                <Image
+                  onClick={handleImgChange}
+                  width="76px" height="76px"
+                  borderRadius={props => props.theme.borderRadius.lv2} src={image} alt="" />
+              </S.ImageLi>
+            )
+          })
+        }
+      </ul>
+      <Image 
+        width="364px" height="364px"
+        borderRadius={props => props.theme.borderRadius.lv2} src={currentImg} alt="" />
+    </S.ImageWrap>
+  )
+}

--- a/src/components/DetailImage/style.js
+++ b/src/components/DetailImage/style.js
@@ -1,0 +1,10 @@
+import styled from "styled-components";
+
+export const ImageWrap = styled.div`
+  display: flex;
+  gap: 26px;
+`;
+
+export const ImageLi = styled.li`
+  margin-bottom: 13px;
+`;

--- a/src/modules/Image/index.jsx
+++ b/src/modules/Image/index.jsx
@@ -6,11 +6,12 @@ const Image = ({
   width,
   height,
   src,
+  onClick,
   alt=""
 }) => {
   return (
     <ImgDefault
-      margin={margin} borderRadius={borderRadius} width={width} height={height} src={src} alt={alt} >
+      onClick={onClick} margin={margin} borderRadius={borderRadius} width={width} height={height} src={src} alt={alt} >
     </ImgDefault>
   )
 }


### PR DESCRIPTION
### PR 목적
- [X] 기능 추가 : 
  기자재 대여 세부 페이지 이미지 컴포넌트 구현
  기자재 이미지 리스트에서 클릭 이벤트 발생 시 메인 이미지 변경

### 전달사항
- 현재 이미지 배열 api가 없기 때문에 임시로 더미 이미지 데이터로 출력
- 이미지 리스트에서 선택 시, 스타일 변경 필요한지 고려 
  => 필요할 시 후에 스타일 수정

