### PR TITLE
Feat: 사용자 내대여정보 랩실 api 구현

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -561,3 +561,29 @@ export const getSpecificDateLabRental = async (date) => {
     return err;
   }
 };
+
+// 사용자 현재 내 랩실 대여 예약 조회 API
+export const getCurrentLabReservation = async () => {
+  try {
+    const response = await instanceUtil.get(`/reservations/labRooms?terminated=false`);
+
+    return response.data;
+  } catch (err) {
+    console.error(err.message);
+    return err;
+  }
+};
+
+// 사용자 랩실 대여 이력 API
+export const getUserLabRentalHistory = async (fromDate, toDate) => {
+  try {
+    const response = await instanceUtil.get(
+      `/rentals/labRooms?from=${fromDate}&to=${toDate}`
+    );
+
+    return response.data;
+  } catch (err) {
+    console.error(err.message);
+    return err;
+  }
+};

--- a/src/components/UserHist/UserEquipHist/index.jsx
+++ b/src/components/UserHist/UserEquipHist/index.jsx
@@ -30,16 +30,16 @@ export default function UserEquipHist() {
           <span>기자재</span>
           <span>상태</span>
         </S.Header>
-        {equipHistory.map((history, i) => (
+        {equipHistory.map((rental, i) => (
           <S.HistList className="equipList" key={i}>
             <S.DateEquip>
-              {dayjs(history.startDate).format("YY년 MM월 DD일(dd)")}
+              {dayjs(rental.startDate).format("YY년 MM월 DD일(dd)")}
             </S.DateEquip>
             <S.DateEquip>
-              {dayjs(history.endDate).format("YY년 MM월 DD일(dd)")}
+              {dayjs(rental.endDate).format("YY년 MM월 DD일(dd)")}
             </S.DateEquip>
             <S.ItemUl>
-              {history.rentalSpecs.map((item, idx) => (
+              {rental.rentalSpecs.map((item, idx) => (
                 <S.ItemLi key={idx}>
                   <span>{item.modelName}</span>
                   <span className={!item.status === "RETURNED" ? "on" : ""}>

--- a/src/components/UserHist/UserLabHist/index.jsx
+++ b/src/components/UserHist/UserLabHist/index.jsx
@@ -1,30 +1,28 @@
 import EmptyData from '../../EmptyData'
 import * as S from "../style"
+import dayjs from "dayjs"
+import { rentalStatus } from "../../../data/rentalStatus"
+import { getUserLabRentalHistory } from "../../../api/api"
+import { useState, useEffect } from "react"
+import { useSelector } from "react-redux"
 
 export default function UserLabHist() {
-  const 랩실대여이력 = [
-    {
-      사용기간: "22년 09월 11일(수) ~ 22년 09월 12일(목)",
-      장소: "한울관",
-      사용인원: 4,
-      정상사용: true,
-    },
-    {
-      사용기간: "22년 09월 11일(수) ~ 22년 09월 12일(목)",
-      장소: "화도관",
-      사용인원: 2,
-      정상사용: true,
-    },
-    {
-      사용기간: "22년 09월 11일(수) ~ 22년 09월 12일(목)",
-      장소: "한울관",
-      사용인원: 6,
-      정상사용: false,
-    },
-  ]
+  const [labHistory, setLabHistory] = useState([])
+  const dualDate = useSelector((state) => state.datePicker.dualDate)
+
+  useEffect(() => {
+    handleGetRentalHistory()
+  }, [dualDate])
+
+  const handleGetRentalHistory = async () => {
+    if (dualDate.firstDate && dualDate.lastDate) {
+      const res = await getUserLabRentalHistory(dualDate.firstDate, dualDate.lastDate)
+      setLabHistory(res.rentals)
+    }
+  }
 
   return (
-    랩실대여이력.length ?
+    labHistory.length ?
       <S.HistWrap>
         <S.Header className="lab">
           <span>사용 기간</span>
@@ -32,12 +30,12 @@ export default function UserLabHist() {
           <span>사용 인원</span>
           <span>상태</span>
         </S.Header>
-        {랩실대여이력.map((랩실, i) => (
+        {labHistory.map((lab, i) => (
           <S.HistList className="lab" key={i}>
-            <span>{랩실.사용기간}</span>
-            <span>{랩실.장소}</span>
-            <span>{랩실.사용인원}</span>
-            <span>{랩실.정상사용 ? "정상 사용" : "불량 사용"}</span>
+            <span>{`${dayjs(lab.startDate).format("YY년 MM월 DD일(dd)")} ~ ${dayjs(lab.startDate).format("YY년 MM월 DD일(dd)")}`}</span>
+            <span>{lab.name === "hanul" ? "한울관" : "화도관"}</span>
+            <span>{lab.amount}</span>
+            <span>{rentalStatus[lab.rentalSpecStatus]}</span>
           </S.HistList>
         ))}
       </S.HistWrap>

--- a/src/components/UserState/UserLabState/index.jsx
+++ b/src/components/UserState/UserLabState/index.jsx
@@ -2,27 +2,24 @@ import * as S from "../style"
 import Button from "../../../modules/Button"
 import useModal from "../../../hook/useModal"
 import EmptyData from '../../EmptyData'
+import { getCurrentLabReservation } from "../../../api/api"
+import { useState, useEffect } from "react"
+import { rentalStatus } from "../../../data/rentalStatus"
+import dayjs from "dayjs"
 
 export default function UserLabState() {
+  const [myRental, setMyRental] = useState([])
   const cancelModal = useModal()
   const contactsModal = useModal()
 
-  const 랩실대여 = [
-    {
-      대여일: "23년 03월 11일(수)",
-      반납일: "23년 03월 12일(목)",
-      장소: "한울관",
-      사용인원: 4,
-      대여중: false,
-    },
-    {
-      대여일: "23년 03월 11일(수)",
-      반납일: "23년 03월 12일(목)",
-      장소: "화도관",
-      사용인원: 6,
-      대여중: true,
-    },
-  ]
+  const handleGetCurrentRental = async () => {
+    const res = await getCurrentLabReservation()
+    setMyRental(res.reservations)
+  }
+
+  useEffect(() => {
+    handleGetCurrentRental()
+  }, [])
 
   const 대표자연락망 = [
     {
@@ -41,7 +38,7 @@ export default function UserLabState() {
   }
 
   return (
-    랩실대여.length ?
+    myRental.length ?
       <>
         <S.HistWrap>
           <S.Header className="lab">
@@ -51,18 +48,18 @@ export default function UserLabState() {
             <span>상태</span>
             <span></span>
           </S.Header>
-          {랩실대여.map((랩실, i) => (
+          {myRental.map((lab, i) => (
             <S.HistList key={i} className="lab labList">
               <div>
-                <p>{랩실.대여일}</p>
+                <p>{dayjs(lab.startDate).format("YY년 MM월 DD일(dd)")}</p>
                 <p>~</p>
-                <p>{랩실.반납일}</p>
+                <p>{dayjs(lab.startDate).format("YY년 MM월 DD일(dd)")}</p>
               </div>
-              <span>{랩실.장소}</span>
-              <span>{랩실.사용인원}</span>
-              <S.State>{랩실.대여중 ? "대여중" : "대여 신청"}</S.State>
+              <span>{lab.name === "hanul" ? "한울관" : "화도관"}</span>
+              <span>{lab.amount}</span>
+              <S.State>{rentalStatus[lab.status]}</S.State>
               <S.BtnWrap>
-                {랩실.장소 === "한울관" && (
+                {lab.name === "hanul" && (
                   <Button
                     text="대표자 연락망"
                     className="main shadow"
@@ -72,7 +69,7 @@ export default function UserLabState() {
                     onClick={contactsModal.open}
                   />
                 )}
-                {!랩실.대여중 && (
+                {lab.status === "RESERVED" && (
                   <Button
                     text="대여취소"
                     className="sub shadow"


### PR DESCRIPTION
### PR 목적

- [x] 기능 추가 : [사용자 내대여정보 랩실 api 구현](https://github.com/KW-GIRIGIRI/kw-rental/commit/a801f2c752f8e1d5353dbc0a8cdba1be0c0a80f9)
- [ ] 스타일 :
- [ ] 리팩토링 :
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [ ] 기타 :

### 요약

<img src="https://github.com/KW-GIRIGIRI/kw-rental/assets/97094709/f2e85fab-b735-40e5-b52e-c957cadf627a" width="600px" />

해당 부분 api 연결 완료

### 전달사항

- 대여 상태 컴포넌트 경우 기자재와 동일하게 나중에 StateListComp 폴더 생성하면 될 듯 <br> 현재는 몰라서 그냥 한 파일에 다 구현했습니다.

### Issue Number

close : #
