### PR TITLE
Design: section padding, 내대여정보 색 수정

### DIFF
--- a/src/components/UserHist/style.js
+++ b/src/components/UserHist/style.js
@@ -4,7 +4,7 @@ export const Div = styled.div`
   margin-top: 16px;
 
   span {
-    border-right: 1px solid ${(props) => props.theme.color.primary.third};
+    border-right: 1px solid ${(props) => props.theme.color.primary.sub};
     height: calc(100% + 20px);
     display: flex;
     align-items: center;
@@ -56,7 +56,7 @@ export const HistWrap = styled.ul`
 export const Header = styled.li`
   padding: 10px 0;
   background-color: ${(props) => props.theme.color.primary.sub};
-  border: 1px solid ${(props) => props.theme.color.primary.third};
+  border: 1px solid ${(props) => props.theme.color.primary.sub};
   display: grid;
   align-items: center;
 
@@ -67,7 +67,7 @@ export const Header = styled.li`
 `;
 
 export const HistList = styled.li`
-  border: 1px solid ${(props) => props.theme.color.primary.third};
+  border: 1px solid ${(props) => props.theme.color.primary.sub};
   border-top: none;
   display: grid;
   align-items: center;
@@ -81,7 +81,7 @@ export const ItemLi = styled.li`
   display: grid;
   align-items: center;
   grid-template-columns: 1fr 1fr;
-  border-bottom: 1px solid ${(props) => props.theme.color.primary.third};
+  border-bottom: 1px solid ${(props) => props.theme.color.primary.sub};
 
   &:last-child {
     border-bottom: none;
@@ -109,5 +109,5 @@ export const DateEquip = styled.p`
   justify-content: center;
   grid-row-start: 1;
   grid-row-end: -1;
-  border-right: 1px solid ${(props) => props.theme.color.primary.third};
+  border-right: 1px solid ${(props) => props.theme.color.primary.sub};
 `;

--- a/src/components/UserState/style.js
+++ b/src/components/UserState/style.js
@@ -37,7 +37,7 @@ export const Div = styled.div`
       display: flex;
       align-items: center;
       justify-content: center;
-      border-right: 1px solid ${(props) => props.theme.color.primary.third};
+      border-right: 1px solid ${(props) => props.theme.color.primary.sub};
     }
   }
 `;
@@ -49,13 +49,13 @@ export const HistWrap = styled.ul`
 export const Header = styled.li`
   background-color: ${(props) => props.theme.color.primary.sub};
   padding: 10px 0;
-  border: 1px solid ${(props) => props.theme.color.primary.third};
+  border: 1px solid ${(props) => props.theme.color.primary.sub};
   display: grid;
   align-items: center;
 `;
 
 export const HistList = styled.li`
-  border: 1px solid ${(props) => props.theme.color.primary.third};
+  border: 1px solid ${(props) => props.theme.color.primary.sub};
   border-top: none;
   display: grid;
   align-items: center;

--- a/src/pages/History/style.js
+++ b/src/pages/History/style.js
@@ -3,7 +3,7 @@ import styled from "styled-components";
 export const Section = styled.div`
   border: 1px solid ${(props) => props.theme.color.primary.sub};
   border-radius: ${(props) => props.theme.borderRadius.lv2};
-  padding: 35px 25px;
+  padding: 35px 30px;
   position: relative;
 `;
 
@@ -18,7 +18,6 @@ export const ButtonWrap = styled.div`
 `;
 
 export const RentalWrap = styled.div`
-  padding: 0 14px;
   position: relative;
 
   & > h2 {

--- a/src/pages/LabRental/style.js
+++ b/src/pages/LabRental/style.js
@@ -1,9 +1,9 @@
 import styled from "styled-components";
 
-export const Section = styled.div`
+export const Section = styled.section`
   border: 1px solid ${(props) => props.theme.color.primary.sub};
   border-radius: ${(props) => props.theme.borderRadius.lv2};
-  padding: 35px 25px;
+  padding: 35px 30px;
   position: relative;
 `;
 

--- a/src/pages/RentalStatus/style.js
+++ b/src/pages/RentalStatus/style.js
@@ -3,7 +3,7 @@ import styled from "styled-components";
 export const Wrapper = styled.section`
   border: 1px solid ${(props) => props.theme.color.primary.sub};
   border-radius: ${(props) => props.theme.borderRadius.lv2};
-  padding: 35px 18px;
+  padding: 35px 30px;
 `;
 
 export const Div = styled.div`


### PR DESCRIPTION
### PR 목적

- [x] 스타일 : [전체 section 가로 padding 값 수정](https://github.com/KW-GIRIGIRI/kw-rental/commit/edc3bcdcc8bcdda579e5fa72827e37f9eab973be), [사용자 내대여정보 border 색상 변경](https://github.com/KW-GIRIGIRI/kw-rental/commit/869a562a2192eb2fe9a3323c935fcfbe4126ebde)

### 요약

<img src="https://github.com/KW-GIRIGIRI/kw-rental/assets/97094709/06a89d58-2364-49b3-aff6-554830d09f84" width="500px" />

- border 색 모두 연하게 변경(primary.sub)

![image](https://github.com/KW-GIRIGIRI/kw-rental/assets/97094709/e24d4578-fdbf-4fc5-9c81-e784b169ffc5)

- 모든 페이지 가로 여백 통일(30px)

### 전달사항

- 없음

### Issue Number

close : #
