### PR TITLE
랩실 소개 페이지 UI, 오류 수정 및 기능 구현

### DIFF
--- a/src/components/QuillUI/QuillEditor/index.jsx
+++ b/src/components/QuillUI/QuillEditor/index.jsx
@@ -31,10 +31,6 @@ export default function QuillEditor({ content, setIsEdit }) {
     })
   }
 
-  const handleRegisterButton = () => {
-    handleEditState()
-  }
-
   const handleEditState = async () => {
     const res = await editLabNotice(hanul ? "hanul" : "hwado", { "notice": input })
     res === 204 && setIsEdit(false)
@@ -80,7 +76,7 @@ export default function QuillEditor({ content, setIsEdit }) {
       <BtnWrap>
         <Button
           text="저장하기"
-          onClick={handleRegisterButton}
+          onClick={handleEditState}
           padding="15px 30px"
           fontSize="15px"
           fontWeight="600"
@@ -89,7 +85,7 @@ export default function QuillEditor({ content, setIsEdit }) {
         />
         <Button
           text="취소하기"
-          onClick={handleEditState}
+          onClick={() => setIsEdit(false)}
           padding="15px 30px"
           fontSize="15px"
           fontWeight="600"

--- a/src/components/QuillUI/QuillEditor/index.jsx
+++ b/src/components/QuillUI/QuillEditor/index.jsx
@@ -7,11 +7,13 @@ import { useRef, useMemo, useState } from "react"
 import Button from "../../../modules/Button"
 import { editLabNotice } from "../../../api/api"
 import { useSelector } from "react-redux"
+import usePreventRefresh from "../../../hook/usePreventRefresh"
 
 export default function QuillEditor({ content, setIsEdit }) {
   const hanul = useSelector(state => state.labControl.lab)
   const quillRef = useRef(null)
   const [input, setInput] = useState(content)
+  usePreventRefresh()
 
   const imageHandler = () => {
     const img = document.createElement('input')

--- a/src/components/QuillUI/QuillEditor/index.jsx
+++ b/src/components/QuillUI/QuillEditor/index.jsx
@@ -47,10 +47,11 @@ export default function QuillEditor({ content, setIsEdit }) {
       return {
         toolbar: {
           container: [
-            [{ 'header': [1, 2, 3, false] }],
+            [{ 'header': [1, 2, 3, 4, 5, 6, false] }],
             [{ 'color': ['#000000', '#e60000', '#ff9900', '#ffff00', '#008a00', '#0066cc', '#9933ff', '#ffffff', '#facccc', '#ffebcc', '#ffffcc', '#cce8cc', '#cce0f5', '#ebd6ff', '#bbbbbb', '#f06666', '#ffc266', '#ffff66', '#66b966', '#66a3e0', '#c285ff', '#888888', '#a10000', '#b26b00', '#b2b200', '#006100', '#0047b2', '#6b24b2', '#444444', '#5c0000', '#663d00', '#666600', '#003700', '#002966', '#3d1466', 'custom-color'] }, { 'background': [] }],
             [{ 'align': [] }],
-            ['bold', 'underline', 'strike'],
+            ['bold', 'italic', 'underline', 'strike', 'blockquote'],
+            [{'list': 'bullet'}],
             ['link'],
             ['image'],
             ['clean']

--- a/src/components/QuillUI/index.jsx
+++ b/src/components/QuillUI/index.jsx
@@ -2,19 +2,22 @@ import { useContext, useState, useEffect } from "react"
 import useTitle from "../../hook/useTitle"
 import QuillEditor from "./QuillEditor"
 import QuillViewer from "./QuillViewer"
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { AuthContext } from "../../context/Context";
 import { useNavigate } from "react-router-dom";
 import { BackBtn } from "./style"
 import { getLabNotice } from "../../api/api"
+import { preventLabEvent } from "../../store/reducer/LabControllerSlice";
 
 export default function QuillUI() {
   const [content, setContent] = useState("")
   const [isEdit, setIsEdit] = useState(false)
   const hanul = useSelector(state => state.labControl.lab)
+  const [lab, setLab] = useState(hanul)
   useTitle(`${hanul ? '한울관' : '화도관'} 랩실 ${isEdit ? '소개 수정' : '소개'}`)
   const { isAuth } = useContext(AuthContext)
   const navigate = useNavigate()
+  const dispatch = useDispatch()
 
   const handleGetLabNotice = async () => {
     const response = await getLabNotice(hanul ? "hanul" : "hwado")
@@ -23,6 +26,12 @@ export default function QuillUI() {
 
   useEffect(() => {
     handleGetLabNotice()
+
+    if (isEdit && lab !== hanul) {
+      if (window.confirm('저장하지 않을 경우, 작성 중인 내용이 사라집니다.')) setIsEdit(false) 
+      else dispatch(preventLabEvent())
+    }
+    setLab(hanul)
   }, [isEdit, hanul])
 
   return (

--- a/src/components/QuillUI/style.js
+++ b/src/components/QuillUI/style.js
@@ -5,6 +5,7 @@ export const EditorWrap = styled.div`
   .ql-toolbar {
     border-top-left-radius: ${(props) => props.theme.borderRadius.lv2};
     border-top-right-radius: ${(props) => props.theme.borderRadius.lv2};
+    font-size: 1rem;
     border: 1px solid ${(props) => props.theme.color.primary.sub};
     background-color: ${(props) => props.theme.color.primary.sub};
   }
@@ -22,15 +23,18 @@ export const EditorWrap = styled.div`
 
     & .ql-blank::before {
       font-style: normal;
-      font-size: 13px;
+      font-size: 1rem;
     }
 
     & p {
-      font-size: 13px;
+      font-size: 1rem;
+      line-height: 1.6;
     }
 
     & li {
       padding: 0 !important;
+      list-style: disc inside;
+      line-height: 1.6;
 
       &::before {
         display: none;
@@ -39,7 +43,7 @@ export const EditorWrap = styled.div`
 
     & ul {
       padding: 0 !important;
-      font-size: 13px;
+      font-size: 1rem;
     }
 
     & > div > div > span {
@@ -61,7 +65,7 @@ export const ViewerWrap = styled.div`
   min-height: 400px;
   border: 1px solid ${(props) => props.theme.color.primary.sub};
   border-radius: 10px;
-  font-size: 13px;
+  font-size: 1rem;
   padding: 20px 15px;
   font: initial !important;
 
@@ -83,7 +87,8 @@ export const ViewerWrap = styled.div`
   }
 
   & p {
-    font-size: 13px;
+    font-size: 1rem;
+    line-height: 1.6;
   }
 
   & a {
@@ -92,7 +97,12 @@ export const ViewerWrap = styled.div`
   }
 
   & ul {
-    font-size: 13px;
+    font-size: 1rem;
+  }
+
+  & li {
+    list-style: disc inside;
+    line-height: 1.6;
   }
 
   & strong {

--- a/src/store/reducer/LabControllerSlice.js
+++ b/src/store/reducer/LabControllerSlice.js
@@ -15,9 +15,12 @@ const labControlSlice = createSlice({
     setLabDate: (state, action) => {
       state.date = action.payload;
     },
+    preventLabEvent: (state) => {
+      state.lab = !state.lab;
+    },
   },
 });
 
-export const { setLab, setLabDate } = labControlSlice.actions;
+export const { setLab, setLabDate, preventLabEvent } = labControlSlice.actions;
 
 export default labControlSlice.reducer;


### PR DESCRIPTION
### PR 목적

- [x] 기능 추가 :
- [랩실 소개 수정 중, 다른 랩실 선택 시 확인 팝업 구현](https://github.com/KW-GIRIGIRI/kw-rental/commit/ceb4872e57078d6d0013e4d8cd345dd7d5681ee2)
```
문제 상황(예시)
1) 한울관 랩실 소개 문구 수정 중, 화도관 버튼 클릭
2) 기존 화도관 소개 내용을 출력하지 않고 작성중인 내용 출력
3) 화도관을 누른 채로 저장하기 버튼 클릭할 경우, 한울관 내용이 변경되는 것이 아니고 화도관 내용이 변경됨

-> 특정 랩실 수정 중, 다른 랩실을 선택할 경우 확인 팝업을 노출하고 사용자의 선택 결과에 따라 화면 흐름 결정
```

- [x] 스타일 :
- [랩실 소개 페이지 디자인 수정](https://github.com/KW-GIRIGIRI/kw-rental/commit/1265bcf235e6e9a6086439524529a110f4ac2aa1)

```
랩실 소개 뷰어 font-size, line-height 가독성 떨어지는 문제로 UI 수정
```

- [x] 버그 수정 :
- [랩실 소개 수정 취소하기 버튼 라우팅 오류 수정](https://github.com/KW-GIRIGIRI/kw-rental/commit/92337d7498d10b5d176974765a09474cdd42cd88)

```
취소하기 버튼 클릭 시, 취소 버튼으로 이어지지 않고 저장 버튼과 동일한 기능하는 오류 수정
```